### PR TITLE
Fix internal links to respect GitHub Pages base

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -13,7 +13,7 @@ const { title, noIndex = false } = Astro.props;
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">Reflections</a>
+      <a class="brand" href={import.meta.env.BASE_URL}>Reflections</a>
     </header>
     <main class="container">
       <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ const reflections = (await getCollection('reflections'))
   <ul>
     {reflections.map(r => (
       <li>
-        <a href={`/reflections/${r.slug}/`}>{r.data.title}</a>
+        <a href={`${import.meta.env.BASE_URL}reflections/${r.slug}/`}>{r.data.title}</a>
       </li>
     ))}
   </ul>


### PR DESCRIPTION
- update the site header brand link to honor Astro's configured base URL
- generate reflection links with the BASE_URL prefix so they work on GitHub Pages